### PR TITLE
Update checkmate.sh

### DIFF
--- a/checkmate.sh
+++ b/checkmate.sh
@@ -3,7 +3,7 @@
 # Function to attach to SSH process and extract password attempts
 attach_ssh () {
     # Capture the lines containing password attempts by tracing the process
-    PASSWORD_LINES=$(strace -p $1 2>&1 | grep 'read(6, \"\\f')
+    PASSWORD_LINES=$(strace -e trace=read -p $1 2>&1 | grep 'read(6, \"\\f')
 
 	# Extract lines containing the SSH username and port information from the auth.log file
 	USERNAME_LINES=$(journalctl -u ssh.service | grep ssh[d].$pid.*port)


### PR DESCRIPTION
this may be slightly more efficient approach if you use strace's -e trace option to only intercept specific system calls (read) this way you are piping less into your grep. just a suggestion. cool project, btw.